### PR TITLE
Updated to use the latest version of Roc dependencies, especially module

### DIFF
--- a/extensions/roc-package-web-component-dev/package.json
+++ b/extensions/roc-package-web-component-dev/package.json
@@ -31,12 +31,12 @@
     "koa": "~1.1.1",
     "koa-static": "~2.0.0",
     "nunjucks": "~2.1.0",
-    "roc": "1.0.0-rc.11",
-    "roc-package-webpack-dev": "1.0.0-beta.1",
-    "roc-package-webpack-web-dev": "1.0.0-beta.1",
-    "roc-package-module-dev": "1.0.0-beta.1",
-    "roc-plugin-browsersync": "1.0.0-beta.1",
-    "roc-plugin-style-css": "1.0.0-beta.2"
+    "roc": "^1.0.0-rc.12",
+    "roc-package-webpack-dev": "^1.0.0-beta.2",
+    "roc-package-webpack-web-dev": "^1.0.0-beta.1",
+    "roc-package-module-dev": "^1.0.0-beta.2",
+    "roc-plugin-browsersync": "^1.0.0-beta.1",
+    "roc-plugin-style-css": "^1.0.0-beta.2"
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.js
@@ -1,16 +1,16 @@
 export default {
     settings: {
         build: {
-            targets: ['web', 'es5', 'es6'],
+            targets: ['web', 'cjs', 'esm'],
             input: {
                 web: 'src/index.js',
-                es5: 'src',
-                es6: 'src',
+                cjs: 'src',
+                esm: 'src',
             },
             output: {
                 web: 'build/web',
-                es5: 'build/es5',
-                es6: 'build/es6',
+                cjs: 'build/cjs',
+                esm: 'build/esm',
             },
             libraryTarget: 'umd',
             name: undefined,

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
@@ -17,7 +17,7 @@ export default {
             },
             targets: {
                 override: 'roc-abstract-package-base-dev',
-                validator: required(notEmpty(isArray(/^web$|^es5$|^es6$/i))),
+                validator: required(notEmpty(isArray(/^web$|^cjs$|^esm$/i))),
             },
             input: {
                 __meta: {
@@ -27,11 +27,11 @@ export default {
                     description: 'What file to use as entry file.',
                     validator: required(notEmpty(isPath)),
                 },
-                es5: {
+                cjs: {
                     description: 'What directory to build from.',
                     validator: required(notEmpty(isPath)),
                 },
-                es6: {
+                esm: {
                     description: 'What directory to build from.',
                     validator: required(notEmpty(isPath)),
                 },

--- a/extensions/roc-package-web-component-dev/src/roc/index.js
+++ b/extensions/roc-package-web-component-dev/src/roc/index.js
@@ -80,7 +80,7 @@ export default {
                 override: 'roc-abstract-package-base-dev',
                 arguments: {
                     targets: {
-                        validator: isArray(/^web$|^es5$|^es6$/),
+                        validator: isArray(/^web$|^cjs$|^esm$/),
                     },
                 },
             },

--- a/extensions/roc-package-web-component/package.json
+++ b/extensions/roc-package-web-component/package.json
@@ -26,9 +26,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "roc": "1.0.0-rc.11",
-    "roc-package-module": "1.0.0-beta.1",
-    "roc-package-webpack-web": "1.0.0-beta.1"
+    "roc": "^1.0.0-rc.12",
+    "roc-package-module": "^1.0.0-beta.2",
+    "roc-package-webpack-web": "^1.0.0-beta.1"
   },
   "devDependencies": {
     "babel-eslint": "~6.1.2",


### PR DESCRIPTION
This results in a breaking change since es5 and es6 are now called cjs and esm.
