### PR TITLE
Made it possible to pass variables to the dev template via settings.

### DIFF
--- a/examples/customVariables/package.json
+++ b/examples/customVariables/package.json
@@ -7,8 +7,7 @@
   "author": "VG",
   "license": "MIT",
   "scripts": {
-      "dev": "roc dev --build-name hest --dev-template-path templates",
-      "roc": "roc -v"
+      "dev": "roc dev --build-name hest --dev-template-path templates"
   },
   "devDependencies": {
     "roc-package-web-component-dev": "*"

--- a/examples/customVariables/package.json
+++ b/examples/customVariables/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "roc-package-module-test",
+  "version": "1.0.0",
+  "description": "Test of roc-package-module",
+  "main": "build/es5/index.js",
+  "jsnext:main": "build/es6/index.js",
+  "author": "VG",
+  "license": "MIT",
+  "scripts": {
+      "dev": "roc dev --build-name hest --dev-template-path templates",
+      "roc": "roc -v"
+  },
+  "devDependencies": {
+    "roc-package-web-component-dev": "*"
+  }
+}

--- a/examples/customVariables/roc.config.js
+++ b/examples/customVariables/roc.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    settings: {
+        dev: {
+            template: {
+                customVariables: {
+                    greeting: 'Hello custom variable world!',
+                    nestedObjects: {
+                        are: 'also',
+                        okay: true
+                    }
+                }
+            }
+        }
+    }
+};

--- a/examples/customVariables/src/index.js
+++ b/examples/customVariables/src/index.js
@@ -1,0 +1,3 @@
+export function talk(msg) {
+    alert(msg);
+}

--- a/examples/customVariables/templates/index.html
+++ b/examples/customVariables/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>{{ name }} - Development</title>
+    </head>
+    <body>
+        <button type="button" onClick="doTalk()">Speak</button>
+        <div id="target"></div>
+        <script src="{{ bundlePath }}"></script>
+        <script type="text/javascript">
+            var target = document.getElementById("target");
+            function doTalk() {
+                {{ name }}.talk("{{ customVariables.greeting }}");
+                target.innerHTML = "customVariables can handle nested objects? {{ customVariables.nestedObjects.are }} {{ customVariables.nestedObjects.okay }}";
+            }
+        </script>
+    </body>
+</html>

--- a/extensions/roc-package-web-component-dev/package.json
+++ b/extensions/roc-package-web-component-dev/package.json
@@ -31,7 +31,7 @@
     "koa": "~1.1.1",
     "koa-static": "~2.0.0",
     "nunjucks": "~2.1.0",
-    "roc": "^1.0.0-rc.12",
+    "roc": "^1.0.0-rc.14",
     "roc-package-webpack-dev": "^1.0.0-beta.2",
     "roc-package-webpack-web-dev": "^1.0.0-beta.1",
     "roc-package-module-dev": "^1.0.0-beta.2",

--- a/extensions/roc-package-web-component-dev/src/commands/nunjucks.js
+++ b/extensions/roc-package-web-component-dev/src/commands/nunjucks.js
@@ -20,15 +20,16 @@ export default function nunjucksRendering() {
 
     // eslint-disable-next-line
     return function* demoRenderer() {
+        const templateVariables = Object.assign({
+            name,
+            bundlePath: stats.script,
+        }, template.variables);
         const trailingSlash = this.path[this.path.length - 1] === '/';
         const templateFile = trailingSlash ?
             `${this.path.substring(1)}index.html` :
             this.path.substring(1);
         try {
-            this.body = nunjucks.render(templateFile, {
-                name,
-                bundlePath: stats.script,
-            });
+            this.body = nunjucks.render(templateFile, templateVariables);
         } catch (err) {
             this.status = 404;
         }

--- a/extensions/roc-package-web-component-dev/src/commands/nunjucks.js
+++ b/extensions/roc-package-web-component-dev/src/commands/nunjucks.js
@@ -20,10 +20,11 @@ export default function nunjucksRendering() {
 
     // eslint-disable-next-line
     return function* demoRenderer() {
-        const templateVariables = Object.assign({
+        const templateVariables = {
             name,
             bundlePath: stats.script,
-        }, template.variables);
+            ...template.variables,
+        };
         const trailingSlash = this.path[this.path.length - 1] === '/';
         const templateFile = trailingSlash ?
             `${this.path.substring(1)}index.html` :

--- a/extensions/roc-package-web-component-dev/src/commands/nunjucks.js
+++ b/extensions/roc-package-web-component-dev/src/commands/nunjucks.js
@@ -23,7 +23,9 @@ export default function nunjucksRendering() {
         const templateVariables = {
             name,
             bundlePath: stats.script,
-            ...template.variables,
+            customVariables: {
+                ...template.customVariables,
+            },
         };
         const trailingSlash = this.path[this.path.length - 1] === '/';
         const templateFile = trailingSlash ?

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.js
@@ -22,7 +22,7 @@ export default {
         dev: {
             template: {
                 path: undefined,
-                variables: {},
+                customVariables: {},
             },
             demoPort: 3002,
             serve: [],

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.js
@@ -22,6 +22,7 @@ export default {
         dev: {
             template: {
                 path: undefined,
+                variables: {},
             },
             demoPort: 3002,
             serve: [],

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
@@ -56,8 +56,9 @@ export default {
                         '"name" and "bundlePath".',
                     validator: notEmpty(isPath),
                 },
-                variables: {
-                    description: 'An object representing variables to expose to the dev template. Will be merged with the default template variables.',
+                customVariables: {
+                    description: 'An object representing custom variables to expose to the dev template. The properties of ' +
+                        'the object can be referenced in the template by using {{ customVariables.myPropertyName }}.',
                     validator: required(isObject()),
                 },
             },

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
@@ -59,7 +59,7 @@ export default {
                 customVariables: {
                     description: 'An object representing custom variables to expose to the dev template. The properties of ' +
                         'the object can be referenced in the template by using {{ customVariables.myPropertyName }}.',
-                    validator: required(isObject()),
+                    validator: required(isObject({ unmanaged: true })),
                 },
             },
             demoPort: {

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
@@ -4,6 +4,7 @@ import {
     isArray,
     isString,
     isInteger,
+    isObject,
     required,
     notEmpty,
 } from 'roc/validators';
@@ -54,6 +55,10 @@ export default {
                         'current working directory or absolute. Uses nunjucks and two variables are available, ' +
                         '"name" and "bundlePath".',
                     validator: notEmpty(isPath),
+                },
+                variables: {
+                    description: 'An array of variables to expose to the dev template. Will be merged with the default template variables.',
+                    validator: required(isObject()),
                 },
             },
             demoPort: {

--- a/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
+++ b/extensions/roc-package-web-component-dev/src/config/roc.config.meta.js
@@ -57,7 +57,7 @@ export default {
                     validator: notEmpty(isPath),
                 },
                 variables: {
-                    description: 'An array of variables to expose to the dev template. Will be merged with the default template variables.',
+                    description: 'An object representing variables to expose to the dev template. Will be merged with the default template variables.',
                     validator: required(isObject()),
                 },
             },


### PR DESCRIPTION
This pull request adds a setting for passing additional template variables to the nunjuck template the dev server uses. One use case for this is to be able to set secrets not suitable for version control in the shell environment for developers and pass them into the demo this way.
